### PR TITLE
only use cs_id <= 5, non-coding TCPs must be near a single coding TGP…

### DIFF
--- a/a_create_causal_noncausal_trait_gene_pairs.R
+++ b/a_create_causal_noncausal_trait_gene_pairs.R
@@ -1,59 +1,85 @@
 
 
 #-------------------------------------------------------------------------------
-#   Find coding TGPs
+#   Format credible sets
 #-------------------------------------------------------------------------------
 
 # Load libraries
 suppressPackageStartupMessages( library(data.table) )
 suppressPackageStartupMessages( library(dplyr) )
 
-# Read in V2G
-maindir <- file.path( Sys.getenv("HOME"), "projects/causal_genes/" )
-v2g_file <- file.path( maindir, "UKB_AllMethods_GenePrioritization.txt.gz" )
-v2g <- fread(v2g_file)
-v2g$tcp <- paste( v2g$trait, v2g$region, v2g$cs_id, sep="_" )
-NROW(v2g)
-head( v2g, 2 )
+# Read in gencode gene boundaries
+gencode <- fread("~/projects/causal_genes/gene_locations.tsv")
 
-# Extract coding TCPs and TGPs (coding PIP > 50%)
-idx <- !is.na(v2g$coding_prob) & v2g$coding_prob > 0.5
-tcp_c <- unique( v2g$tcp[idx] )
-tgp_c <- v2g[ idx , ]
-length(tcp_c)
-head( tgp_c, 2 )
-
-
-#-------------------------------------------------------------------------------
-#   Format credible sets
-#-------------------------------------------------------------------------------
+# Independent traits
+it0 <- fread("~/projects/causal_genes/weeks2023_table_s1.csv")
+it <- it0$Trait[ it0$Cohort == "UKB" & it0$`Independent traits (for meta-analysis)` ]
+length(it)
 
 # Read in CS column names
 # Read in CSs, add column names
+maindir <- file.path( Sys.getenv("HOME"), "projects/causal_genes/" )
 cs_colnames <- fread( file.path( maindir, "release1.1", "UKBB_94traits_release1.cols" ), 
                       header=FALSE )
 cs <- fread( file.path( maindir, "release1.1", "UKBB_94traits_release1.bed.gz" ) )
 names(cs) <- cs_colnames$V1
 
-# Remove SNPs that are not in CSs
+# Remove SNPs that are not in CSs, or are in CSs with the 6th+ worst ABF
 # Subset to SUSIE CSs only
 # Add P value and TCP columns
-cs2 <- cs[  cs$cs_id > 0 , ]
+cs2 <- cs[  cs$cs_id > 0 & cs$cs_id < 6 & cs$trait %in% it , ]
 cs3 <- cs2[ cs2$method == "SUSIE" , ]
 cs3$p <- z_to_p( z=sqrt(cs3$chisq_marginal) )
 cs3$tcp <- paste( cs3$trait, cs3$region, cs3$cs_id, sep="_" )
 head( cs3, 1 )
 
-# Add "number of CSs in region" to each CS to be used as a covariate later
-trp <- paste( cs3$trait, cs3$region, sep="_" )
-cs3$n_cs_in_region <- as.numeric(NA)
-for( i in unique(trp) ){
-  val <- length( unique( cs3$tcp[ trp == i ] ) )
-  set( x     = cs3, 
-       i     = which( trp == i ), 
-       j     = "n_cs_in_region", 
-       value = val )
-}
+# Add pip_max and pip_ratio
+pip_max <- tapply( X=cs3$pip, INDEX=cs3$tcp, FUN=max )
+cs3$pip_max <- pip_max[ match( cs3$tcp, names(pip_max) ) ]
+cs3$pip_ratio <- cs3$pip / cs3$pip_max
+summary(cs3$pip_ratio)
+
+# Subset to CSs where PIP > 25% and pip_ratio = 1
+cs4 <- cs3[ cs3$pip > 0.25 & cs3$pip_ratio == 1 , ]
+NROW(cs3); NROW(cs4)
+
+
+#-------------------------------------------------------------------------------
+#   Find coding TGPs
+#-------------------------------------------------------------------------------
+
+# Read in V2G
+vg_file <- file.path( maindir, "v2g_file.tsv" )
+vg0 <- fread(vg_file)
+vg <- vg0[ vg0$trait %in% it , ]
+vg$tcp <- paste( vg$trait, vg$region, vg$cs_id, sep="_" )
+NROW(vg0); NROW(vg)
+head( vg, 2 )
+
+# Extract coding TGPs and TCPs (coding PIP > 25% + maxPIP)
+# idx1 <- !is.na(vg$coding_prob)
+# idx2 <- vg$coding_prob > 0.5
+# idx3 <- vg$coding_prob > 0.25 & vg$tcp %in% cs4$tcp
+# idx <- idx1 & ( idx2 | idx3 )
+# tgp_c0 <- vg[ idx , ]
+# NROW(tgp_c0)
+# tcp_c_all <- unique(tgp_c0$tcp)
+
+# Extract coding TGPs and TCPs (coding PIP > 50%)
+idx <- !is.na(vg$coding_prob) & vg$coding_prob > 0.5
+tgp_c0 <- vg[ idx , ]
+tcp_c_all <- unique(tgp_c0$tcp)
+
+# Subset to coding TGPs that 1) use canonical ENSGIDs, 2) have cs_id <= 5
+# (5th strongest CS in the region or better), and removing duplicated TGPs
+# (preferentially retaining low cs_id)
+tgp_c0 <- tgp_c0[ order( tgp_c0$trait, tgp_c0$region, tgp_c0$cs_id ) , ]
+tgp_c  <- tgp_c0[ tgp_c0$ensgid %in% gencode$ENSGID & 
+                  tgp_c0$cs_id <= 5 & 
+                  !duplicated( tgp_c0[ , c( "trait", "ensgid" ) ] ) , ]
+tcp_c <- unique(tgp_c$tcp)
+NROW(tgp_c0); NROW(tgp_c); length(tcp_c)
+head( tgp_c, 2 )
 
 
 #-------------------------------------------------------------------------------
@@ -61,7 +87,7 @@ for( i in unique(trp) ){
 #-------------------------------------------------------------------------------
 
 # Extract non-coding TCPs
-tcp_n <- setdiff( cs3$tcp, tcp_c )
+tcp_n <- setdiff( cs3$tcp, tcp_c_all )
 length(tcp_n)
 
 # Subset coding and non-coding TCPs to those in shared TRPs
@@ -74,7 +100,7 @@ tcp_n2 <- tcp_n[ trp_n %in% trp_b ]
 length(tcp_c); length(tcp_c2)
 length(tcp_n); length(tcp_n2)
 
-# Remove CSs >300kb from causal genes
+# Remove non-coding TCPs >300kb from causal genes
 # Loop through non-coding TCPs and flag those that are near a coding TGP
 window <- 3e5
 tcp_n_near0 <- list()
@@ -91,36 +117,39 @@ for( i in seq_along(tcp_n2) ){
   n_cs     <- sub$n_cs_in_region[1]
   
   # Do any coding TGPs have?: same trait, same chromosome, 
-  #   causal start < CS end + 500kb, causal end > CS start - 500kb
+  #   causal start < CS end + window, causal end > CS start - window
   idx <- tgp_c$trait == trait &
     tgp_c$chromosome == chr &
     tgp_c$start <= cs_end   + window &
     tgp_c$end   >= cs_start - window
   
-  # If so, store information about the CS
-  if( any(idx) ){
-    dt <- data.table( tcp=tcp_n2[i], trait=trait, region=region, cs_id=cs_id, 
-                      chr=chr, cs_start=cs_start, cs_end=cs_end, 
+  # If a non-coding TCP is near a single coding TGP, store TCP information
+  if( sum(idx) == 1 ){
+    dt <- data.table( tcp=tcp_n2[i], trait=trait, region=region, cs_id=cs_id,
+                      chr=chr, cs_start=cs_start, cs_end=cs_end,
                       n_cs_snps=NROW(sub), cs_width=cs_end-cs_start,
-                      n_cs_in_region=n_cs )
+                      n_cs_in_region=n_cs, tcp_c=tgp_c$tcp[idx] )
     tcp_n_near0[[i]] <- dt
   }
 }
-tcp_n_near <- do.call( rbind, tcp_n_near0 )
-tcp_n_near <- tcp_n_near[ order( tcp_n_near$trait, 
-                                 tcp_n_near$chr, 
-                                 tcp_n_near$cs_start ) , ]
+tcp_n_near0 <- do.call( rbind, tcp_n_near0 )
+
+# If a coding TCP is associated with multiple non-coding TCPs, only keep the best cs_id (ABF)
+# tcp_n_near0 <- tcp_n_near0[ order( tcp_n_near0$trait, 
+#                                    tcp_n_near0$region, 
+#                                    tcp_n_near0$cs_id ) , ]
+# tcp_n_near  <- tcp_n_near0[ !duplicated(tcp_n_near0$tcp_c) , ]
+# NROW(tcp_n_near0); NROW(tcp_n_near)
+tcp_n_near <- tcp_n_near0
+
+# Extract full CS data for non-coding TCPs near coding TGPs
 cs_n_near  <- cs3[ cs3$tcp %in% tcp_n_near$tcp , ]
-NROW(tcp_n_near); length(tcp_n2); NROW(cs_n_near)
-head(tcp_n_near)
+NROW(cs_n_near)
 
 
 #-------------------------------------------------------------------------------
 #   Extract all genes near non-coding TCPs (near causal TGPs)
 #-------------------------------------------------------------------------------
-
-# Read in gencode gene boundaries
-gencode  <- fread("~/projects/causal_genes/gene_locations.tsv")
 
 # For each non-coding CS near causal TGPs, extract all nearby genes
 all_genes_near_nc_cs0 <- list()
@@ -142,7 +171,7 @@ for( i in seq_along(tcp_n_near$tcp) ){
 all_genes_near_nc_cs <- do.call( rbind, all_genes_near_nc_cs0 )
 colorder <- c( "trait", "gene", "ensgid", "chr", "gene_start", "gene_end",
                "ngenes_nearby", "tcp", "region", "cs_id", "cs_start", "cs_end",
-               "n_cs_snps", "cs_width", "n_cs_in_region" )
+               "n_cs_snps", "cs_width" )
 all_genes_near_nc_cs <- setcolorder( all_genes_near_nc_cs, colorder )
 NROW(all_genes_near_nc_cs)
 
@@ -163,22 +192,27 @@ table(cnc$causal)
 table( duplicated( cnc[ cnc$causal  , c( "trait", "ensgid" ) ] ) )
 table( duplicated( cnc[ !cnc$causal , c( "trait", "ensgid" ) ] ) )
 
-# Removed loci with < 2 genes in them
+# Remove loci with < 2 genes in them
 cnc2 <- cnc[ cnc$ngenes_nearby >= 2 , ]
-NROW(cnc); NROW(cnc2)
+
+# Remove traits with <5 causal genes
+n_causal_per_trait <- sort( table( cnc2$trait[ cnc2$causal ] ), decreasing=TRUE )
+ge_5_causal_per_trait <- names(n_causal_per_trait)[ n_causal_per_trait >= 5 ]
+cnc3 <- cnc2[ cnc2$trait %in% ge_5_causal_per_trait , ]
+table(cnc$causal); table(cnc2$causal); table(cnc3$causal)
 
 # Write causal/non-causal trait-gene pairs to file
 causal_gene_file <- file.path( maindir, "causal_noncausal_trait_gene_pairs",
                                "causal_noncausal_trait_gene_pairs_300kb.tsv" )
-fwrite( x=cnc2, file=causal_gene_file, sep="\t" )
+fwrite( x=cnc3, file=causal_gene_file, sep="\t" )
 
 
 #-------------------------------------------------------------------------------
-#   Write out coding genes, distal nearest genes, and distal NG+TP genes
+#   Write out coding genes, distal nearest genes, and nearby non-causal genes
 #-------------------------------------------------------------------------------
 
 # Non-coding TCPs that are far from fine-mapped (PIP > 50%) coding TCPs
-tcp_n_far <- setdiff( tcp_n, tcp_n_near$tcp )
+tcp_n_far <- setdiff( tcp_n, tcp_n2 )
 length(tcp_n); NROW(tcp_n_near); length(tcp_n_far)
 
 # All (coding and non-coding) fine-mapped TCPs
@@ -187,12 +221,12 @@ tcp_a_fine <- unique( cs3$tcp[ cs3$pip > 0.5 ] )
 # Non-coding fine-mapped TCPs that are far from fine-mapped coding TCPs
 tcp_n_far_fine <- intersect( tcp_n_far, tcp_a_fine )
 # tcp_n_far_fine <- tcp_n_far
-length(tcp_n_far); length(tcp_a_fine); length(tcp_n_far_fine); length(tcp_c2)
+length(tcp_n_far); length(tcp_a_fine); length(tcp_n_far_fine)
 
 # Find the nearest gene to each distal non-coding fine-mapped TCP
 # If multiple genes are equal, take the one with the higher POPS score
-ng_n_far_fine0 <- v2g[ v2g$tcp %in% tcp_n_far_fine & 
-                       v2g$distance_genebody_rank == 1 , ]
+ng_n_far_fine0 <- vg[ vg$tcp %in% tcp_n_far_fine & 
+                       vg$distance_genebody_rank == 1 , ]
 ng_n_far_fine0 <- ng_n_far_fine0[ order( ng_n_far_fine0$tcp, -ng_n_far_fine0$pops_score ) , ]
 ng_n_far_fine  <- ng_n_far_fine0[ !duplicated(ng_n_far_fine0$tcp) , ]
 NROW(ng_n_far_fine0); NROW(ng_n_far_fine)
@@ -226,8 +260,8 @@ for( i in seq_along(distal_nearest_genes$ensgid) ){
   start <- gencode$START[ gencode$ENSGID == distal_nearest_genes$ensgid[i] ]
   end   <- gencode$END[   gencode$ENSGID == distal_nearest_genes$ensgid[i] ]
   local <- gencode[ gencode$CHR == chr & 
-                      gencode$END > start - 3e5 & 
-                      gencode$START < end + 3e5 &
+                      gencode$END > start - window & 
+                      gencode$START < end + window &
                       gencode$ENSGID != distal_nearest_genes$ensgid[i], ]
   noncausal_near_ng0[[i]] <- local[ , c( "NAME", "ENSGID" ) ]
 }
@@ -253,15 +287,30 @@ distal_genes_file          <- file.path( maindir,
 noncausal_near_distal_file <- file.path( maindir, 
                                          "causal_noncausal_trait_gene_pairs",
                                          "noncausal_genes_near_distal.tsv" )
-fwrite( x=coding_genes,           sep="\t", file=coding_genes_file )
-fwrite( x=noncausal_near_coding,  sep="\t", file=noncausal_near_coding_file )
-fwrite( x=distal_ng_and_tp_genes, sep="\t", file=distal_genes_file )
-fwrite( x=noncausal_near_ng,    sep="\t", file=noncausal_near_distal_file )
+fwrite( x=coding_genes,          sep="\t", file=coding_genes_file )
+fwrite( x=noncausal_near_coding, sep="\t", file=noncausal_near_coding_file )
+fwrite( x=distal_nearest_genes,  sep="\t", file=distal_genes_file )
+fwrite( x=noncausal_near_ng,     sep="\t", file=noncausal_near_distal_file )
 
 
 #-------------------------------------------------------------------------------
 #   Done
 #-------------------------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/x_merge_v2g_files.R
+++ b/x_merge_v2g_files.R
@@ -1,0 +1,55 @@
+
+# Input arguments
+maindir <- "~/projects/causal_genes/"
+
+# Load libraries
+suppressPackageStartupMessages( library(data.table) )
+suppressPackageStartupMessages( library(dplyr) )
+
+# Read in gencode gene boundaries
+gencode  <- fread("~/projects/causal_genes/gene_locations.tsv")
+
+# Read in main V2G
+vg_file1 <- file.path( maindir, "UKB_AllMethods_GenePrioritization.txt.gz" )
+vg1 <- fread(vg_file1)
+vg1 <- vg1[ order( vg1$trait, vg1$region, vg1$cs_id, vg1$ensgid ) , ]
+
+# Read in MAGMA and SMR V2G
+# One row per credible set variant. We extract gene-level results for the top variant.
+vg_file2 <- file.path( maindir, "PoPS_UKBB_noncoding_validation_1348CSs_v2.txt.gz" )
+vg2 <- fread(vg_file2)
+vg2 <- vg2[ order( vg2$trait, vg2$region, vg2$cs_id, vg2$ensgid, -vg2$pip ) , ]
+idx <- duplicated( vg2[ , c( "trait", "region", "cs_id", "ensgid" ) ] )
+vg2 <- vg2[ !idx , ]
+gcols_vg2 <- c( "trait", "region", "cs_id", "ensgid", "smr_p", "smr_rank", 
+                "magma_score", "magma_rank" )
+
+# Read in DEPICT and NetWAS V2G
+vg_file3 <- file.path( maindir, "netwas_depict.txt.gz" )
+vg3 <- fread(vg_file3)
+vg3 <- vg3[ !grepl( pattern="^PASS_", x=vg3$trait ) , ]
+names(vg3)[ names(vg3) == "ENSGID" ] <- "ensgid"
+vg3$trait <- sub( pattern="^UKB_", replacement="", x=vg3$trait )
+
+# Merge
+j1 <- left_join( x=vg1, y=vg2[,..gcols_vg2] )
+j2 <- left_join( x=j1, y=vg3 )
+
+# Remove genes >300kb from the lead variant and non-canonical ENSGIDs
+j3 <- j2[ j2$distance_genebody < 300e3 & j2$ensgid %in% gencode$ENSGID , ]
+NROW(vg1); NROW(vg2); NROW(vg3)
+NROW(j1); NROW(j3)
+
+# Write
+vg_outfile <- file.path( maindir, "v2g_file.tsv" )
+fwrite( x=j3, file=vg_outfile, sep="\t" )
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
…, remove traits with <5 causal genes, make a new script for combining V2G, flip distance sign, add Mostafavi 2023 covariates, automate correcting for gene-level covariates, add code to perform leave-one-trait-out analyses, more intelligently select training and test phenotypes, add a function for deviance explained, add a section for comparing the deviance explained of competing features